### PR TITLE
feat: アカウント名でのコスト表示と処理の安定性向上

### DIFF
--- a/AZ_client_secret_template.json
+++ b/AZ_client_secret_template.json
@@ -1,5 +1,6 @@
 [
     {
+        "az_subscription_name": "<サブスクリプション名>",
         "az_subscription_id": "<サブスクリプションID>",
         "az_client_secret": "<クライアントシークレット>",
         "az_client_id": "<クライアント(アプリ)ID>",


### PR DESCRIPTION
AWS/Azureのコスト集計とレポート表示機能を改善しました。

主な変更点:
- AWS Organizations APIを利用して、AWSアカウントIDとアカウント名の対応表を最初に一括で取得するように変更。これにより、API呼び出し回数を削減し、処理を効率化。
- コスト集計の内部処理では、キーとして安定したアカウントID/サブスクリプションIDを使用。
- メール生成時に、IDを人間が読みやすいアカウント名に変換して表示するように修正。これにより、アカウント名に特殊文字が含まれる場合でも安定して動作するように改善。
- AWSとAzureのアカウント別コストを、コストが高い順にソートして表示するように変更し、レポートの可読性を向上。